### PR TITLE
Add configurable list view for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ services:
       #- OIDC_REDIRECT_URI=http(s)://urlofyourgptwol(:port) # Base URL of your GPTWOL instance; default is not set 
       #- SCRIPT_NAME=/my-app # Uncomment this line to run the app under a prefix; default is not set
       #- ENABLE_ADD_DEL=true # Enable or disable ADD computer and Delete computer buttons; default is true
+      #- VIEW_MODE=switch # Set the device display mode: cards, list or switch; default is switch
       #- ENABLE_REFRESH=true # Enable or disable automatic status refresh; default is true
       #- REFRESH_INTERVAL=30 # Uncomment to change time between each status check for icmp, arp or tcp, can (in s); default value is 30 seconds
       #- PING_TIMEOUT=300 #Uncomment to change the time to wait for a ping answer in (in ms); default value is 300 milliseconds
@@ -101,6 +102,22 @@ services:
 Run the application
 ```
 docker compose up -d
+```
+
+#### Device display mode
+
+Set `VIEW_MODE` to choose how devices are shown on the main page:
+
+| Value | Behavior |
+| ----- | -------- |
+| `switch` | Show the card view by default and provide a button to switch to list view. This is the default. |
+| `cards` | Show only the card view and hide the view switch. |
+| `list` | Show only the list view and hide the view switch. |
+
+Example:
+```
+environment:
+  - VIEW_MODE=list
 ```
 
 ### With docker

--- a/app/templates/css/styles.css
+++ b/app/templates/css/styles.css
@@ -19,6 +19,96 @@
   background-color: #ff0000;
 }
 
+.computer-list-wrapper {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.computer-list {
+  margin-bottom: 0;
+  min-width: 760px;
+}
+
+.computer-list th {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.sortable-column {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sortable-column::after {
+  color: var(--bs-secondary-color);
+  content: "\f0dc";
+  font-family: "Font Awesome 7 Free";
+  font-size: 0.75rem;
+  font-weight: 900;
+  margin-left: 0.4rem;
+}
+
+.sortable-column.sorted-asc::after {
+  content: "\f0de";
+}
+
+.sortable-column.sorted-desc::after {
+  content: "\f0dd";
+}
+
+.computer-list td {
+  vertical-align: middle;
+}
+
+.status-column {
+  width: 112px;
+}
+
+.name-column {
+  min-width: 180px;
+}
+
+.actions-column {
+  width: 168px;
+}
+
+.network-address {
+  font-family: monospace;
+  white-space: nowrap;
+}
+
+.schedule-badges,
+.action-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.schedule-badges {
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
+}
+
+.action-buttons {
+  justify-content: flex-end;
+}
+
+.check-method {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.view-toggle {
+  border: 1px solid var(--bs-border-color);
+}
+
+.view-toggle.active {
+  background-color: var(--bs-secondary);
+  color: var(--bs-light);
+}
+
 .delete-button,
 .add-button,
 .search-input {

--- a/app/templates/js/searchbar.js
+++ b/app/templates/js/searchbar.js
@@ -1,22 +1,36 @@
+const sortDirections = {};
+
+document.addEventListener('DOMContentLoaded', function() {
+  const searchInput = document.querySelector('.search-input');
+  if (searchInput) {
+    searchInput.addEventListener('input', filterComputers);
+  }
+
+  document.querySelectorAll('.view-toggle').forEach(button => {
+    button.addEventListener('click', () => setViewMode(button.dataset.view));
+  });
+
+  document.querySelectorAll('.sortable-column').forEach(column => {
+    column.addEventListener('click', () => sortComputers(column.dataset.sort));
+  });
+});
+
 function filterComputers() {
   const query = document.querySelector('.search-input').value.toLowerCase();
-  const cards = document.querySelectorAll('.computer-card');
+  const computers = document.querySelectorAll('.computer-entry');
 
-  cards.forEach(card => {
-    const title = card.querySelector('.title-sortable .sortable').textContent.toLowerCase();
-    const ip = card.querySelector('.info-sortable .sortable:nth-of-type(1)').textContent.toLowerCase(); // IP address
-    const mac = card.querySelector('.info-sortable .sortable:nth-of-type(2)').textContent.toLowerCase(); // MAC address
+  computers.forEach(computer => {
+    const title = computer.dataset.name.toLowerCase();
+    const ip = computer.dataset.ip.toLowerCase();
+    const mac = computer.dataset.mac.toLowerCase();
 
     if (title.includes(query) || ip.includes(query) || mac.includes(query)) {
-      card.classList.remove('hidden'); // Show card
+      computer.classList.remove('hidden');
     } else {
-      card.classList.add('hidden'); // Hide card
+      computer.classList.add('hidden');
     }
   });
 }
-
-// Attach the filter function to the input event
-document.querySelector('.search-input').addEventListener('input', filterComputers);
 
 function clearSearchInput() {
   const searchInput = document.querySelector('.search-input');
@@ -24,13 +38,83 @@ function clearSearchInput() {
   filterComputers(); // Reset the filter
 }
 
+function setViewMode(viewMode) {
+  const cardsView = document.getElementById('cardsView');
+  const listView = document.getElementById('listView');
+
+  if (viewMode === 'list') {
+    if (cardsView) {
+      cardsView.classList.add('hidden');
+    }
+    if (listView) {
+      listView.classList.remove('hidden');
+    }
+  } else {
+    if (listView) {
+      listView.classList.add('hidden');
+    }
+    if (cardsView) {
+      cardsView.classList.remove('hidden');
+    }
+  }
+
+  document.querySelectorAll('.view-toggle').forEach(button => {
+    button.classList.toggle('active', button.dataset.view === viewMode);
+  });
+}
+
 function ipToNumber(ip) {
-  return ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0);
+  if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(ip)) {
+    return null;
+  }
+
+  const octets = ip.split('.').map(Number);
+  if (octets.some(octet => octet < 0 || octet > 255)) {
+    return null;
+  }
+
+  return octets.reduce((acc, octet) => (acc * 256) + octet, 0);
+}
+
+function getSortValue(computer, criteria) {
+  switch (criteria) {
+    case 'name':
+      return computer.dataset.name.toLowerCase();
+    case 'ip':
+      return computer.dataset.ip;
+    case 'mac':
+      return computer.dataset.mac.toLowerCase();
+    case 'check':
+      return computer.dataset.check.toLowerCase();
+    case 'status':
+      return computer.dataset.status || 'unknown';
+    default:
+      return '';
+  }
+}
+
+function compareComputers(a, b, criteria, direction) {
+  const directionFactor = direction === 'desc' ? -1 : 1;
+
+  if (criteria === 'ip') {
+    const aIpNumber = ipToNumber(a.dataset.ip);
+    const bIpNumber = ipToNumber(b.dataset.ip);
+
+    if (aIpNumber !== null && bIpNumber !== null) {
+      return (aIpNumber - bIpNumber) * directionFactor;
+    }
+  }
+
+  return String(getSortValue(a, criteria)).localeCompare(
+    String(getSortValue(b, criteria)),
+    undefined,
+    { numeric: true }
+  ) * directionFactor;
 }
 
 function sortComputers(criteria) {
-  const cardsContainer = document.querySelector('.row.row-sortable');
-  const cards = Array.from(cardsContainer.children); // Convert NodeList to Array
+  sortDirections[criteria] = sortDirections[criteria] === 'asc' ? 'desc' : 'asc';
+  const direction = sortDirections[criteria];
 
   // Update the active class in the dropdown
   const dropdownItems = document.querySelectorAll('.dropdown-item');
@@ -38,36 +122,23 @@ function sortComputers(criteria) {
     item.classList.remove('active'); // Remove active class from all items
   });
 
-  // Sort the cards based on the selected criteria
-  cards.sort((a, b) => {
-    let aValue, bValue;
+  const activeDropdownItem = Array.from(dropdownItems).find(item => item.getAttribute('onclick') === `sortComputers('${criteria}')`);
+  if (activeDropdownItem) {
+    activeDropdownItem.classList.add('active');
+  }
 
-    switch (criteria) {
-      case 'name':
-        aValue = a.querySelector('.title-sortable .sortable').textContent.toLowerCase();
-        bValue = b.querySelector('.title-sortable .sortable').textContent.toLowerCase();
-        dropdownItems[0].classList.add('active'); // Sort by Name
-        return aValue.localeCompare(bValue); // Compare values for sorting
-
-      case 'ip':
-        const aIp = a.querySelector('.info-sortable .sortable:nth-of-type(1)').textContent;
-        const bIp = b.querySelector('.info-sortable .sortable:nth-of-type(1)').textContent;
-        dropdownItems[1].classList.add('active'); // Sort by IP
-
-        return ipToNumber(aIp) - ipToNumber(bIp); // Compare numeric values
-
-      case 'mac':
-        aValue = a.querySelector('.info-sortable .sortable:nth-of-type(2)').textContent.toLowerCase(); // MAC address
-        bValue = b.querySelector('.info-sortable .sortable:nth-of-type(2)').textContent.toLowerCase(); // MAC address
-        dropdownItems[2].classList.add('active'); // Sort by MAC
-        return aValue.localeCompare(bValue); // Compare values for sorting
+  document.querySelectorAll('.sortable-column').forEach(column => {
+    column.classList.remove('sorted-asc', 'sorted-desc');
+    if (column.dataset.sort === criteria) {
+      column.classList.add(direction === 'asc' ? 'sorted-asc' : 'sorted-desc');
     }
   });
 
-  // Clear the current cards and append sorted cards
-  cardsContainer.innerHTML = '';
-  cards.forEach(card => cardsContainer.appendChild(card));
-}
+  document.querySelectorAll('.computer-sortable').forEach(computersContainer => {
+    const computers = Array.from(computersContainer.children);
+    computers.sort((a, b) => compareComputers(a, b, criteria, direction));
 
-// Attach the filter function to the input event
-document.querySelector('.search-input').addEventListener('input', filterComputers);
+    computersContainer.innerHTML = '';
+    computers.forEach(computer => computersContainer.appendChild(computer));
+  });
+}

--- a/app/templates/js/updatestatus.js
+++ b/app/templates/js/updatestatus.js
@@ -1,38 +1,69 @@
 // ---
 // Status Indicator
 window.addEventListener('load', function() {
-  // Get all status indicator elements
-  const statusIndicators = document.querySelectorAll('.status-indicator');
-
-  // Loop through each status indicator element
-  statusIndicators.forEach(function(indicator) {
-    // Extract IP address and test type from the data attributes
-    const ip_address = indicator.getAttribute('data-ip-address');
-    const test_type = indicator.getAttribute('data-test-type');
-    // Find the corresponding button element
-    const buttonElement = indicator.closest('.card').querySelector('.status-power');
-    updateStatus(ip_address, test_type, indicator, buttonElement);
-  });
+  updateAllStatuses();
 });
 
-function updateStatus(ip_address, test_type, element, buttonElement) {
+function updateAllStatuses() {
+  const checked = new Set();
+
+  document.querySelectorAll('.status-indicator').forEach(function(indicator) {
+    const ip_address = indicator.getAttribute('data-ip-address');
+    const test_type = indicator.getAttribute('data-test-type');
+    const key = `${ip_address}|${test_type}`;
+
+    if (checked.has(key)) {
+      return;
+    }
+
+    checked.add(key);
+    updateStatus(ip_address, test_type);
+  });
+}
+
+function getStatusPowerButton(indicator) {
+  const computerEntry = indicator.closest('.computer-entry');
+  return computerEntry ? computerEntry.querySelector('.status-power') : null;
+}
+
+function getMatchingIndicators(ip_address, test_type) {
+  return Array.from(document.querySelectorAll('.status-indicator')).filter(indicator => (
+    indicator.getAttribute('data-ip-address') === ip_address &&
+    indicator.getAttribute('data-test-type') === test_type
+  ));
+}
+
+function updateStatus(ip_address, test_type) {
   // Make an HTTP GET request to the check_status endpoint
-  fetch(`${check_status_url}?ip_address=${ip_address}&test_type=${test_type}`)
+  fetch(`${check_status_url}?ip_address=${encodeURIComponent(ip_address)}&test_type=${encodeURIComponent(test_type)}`)
     .then(response => response.text())
     .then(status => {
-      // Update the class of the element based on the returned status
-      if (status === 'awake') {
-        element.classList.remove('asleep');
-        element.classList.add('awake');
-        buttonElement.classList.remove('btn-success');
-        buttonElement.classList.add('btn-danger');
-        buttonElement.title = 'Sleep';
-      } else {
-        element.classList.remove('awake');
-        element.classList.add('asleep');
-        buttonElement.classList.remove('btn-danger');
-        buttonElement.classList.add('btn-success');
-        buttonElement.title = 'Wake';
-      }
+      getMatchingIndicators(ip_address, test_type).forEach(element => {
+        const computerEntry = element.closest('.computer-entry');
+        const buttonElement = getStatusPowerButton(element);
+
+        if (computerEntry) {
+          computerEntry.dataset.status = status;
+        }
+
+        // Update the class of the element based on the returned status
+        if (status === 'awake') {
+          element.classList.remove('asleep');
+          element.classList.add('awake');
+          if (buttonElement) {
+            buttonElement.classList.remove('btn-success');
+            buttonElement.classList.add('btn-danger');
+            buttonElement.title = 'Sleep';
+          }
+        } else {
+          element.classList.remove('awake');
+          element.classList.add('asleep');
+          if (buttonElement) {
+            buttonElement.classList.remove('btn-danger');
+            buttonElement.classList.add('btn-success');
+            buttonElement.title = 'Wake';
+          }
+        }
+      });
     });
 }

--- a/app/templates/wol_form.html
+++ b/app/templates/wol_form.html
@@ -24,14 +24,7 @@
 
       {% if os.environ.get('ENABLE_REFRESH') != 'false' -%}
         setInterval(() => {
-          // Update the status of all computers
-          for (let element of document.getElementsByClassName('status-indicator')) {
-            const ip_address = element.getAttribute('data-ip-address');
-            const test_type = element.getAttribute('data-test-type');
-            // Find the corresponding button element
-            const buttonElement = element.closest('.card').querySelector('.status-power');
-            updateStatus(ip_address, test_type, element, buttonElement);
-          }
+          updateAllStatuses();
         {% if os.environ.get('REFRESH_INTERVAL') -%}
         }, {{ os.environ.get('REFRESH_INTERVAL') | int * 1000 }});
         {% else -%}
@@ -42,6 +35,10 @@
   </head>
 
   <body>
+    {% set view_mode = os.environ.get('VIEW_MODE', 'switch').strip().lower() %}
+    {% if view_mode not in ['cards', 'list', 'switch'] %}
+      {% set view_mode = 'switch' %}
+    {% endif %}
     <nav class="navbar navbar-expand-md sticky-top" style="background-color: rgba(0, 0, 0, 0.05);">
       <div class="container-lg">
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
@@ -98,6 +95,16 @@
               <li><a class="dropdown-item" href="#" onclick="sortComputers('mac')">Sort by MAC</a></li>
             </ul>
           </div>
+          {% if view_mode == 'switch' -%}
+          <div class="btn-group">
+            <button type="button" class="btn active view-toggle" data-view="cards" title="Card view" aria-label="Card view">
+              <i class="fa-solid fa-grip"></i>
+            </button>
+            <button type="button" class="btn view-toggle" data-view="list" title="List view" aria-label="List view">
+              <i class="fa-solid fa-list"></i>
+            </button>
+          </div>
+          {% endif -%}
           <div class="btn-group">
             <input type="text" placeholder="Search Name, MAC or IP" class="search-input border border-secondary" value="">
             <button type="button" class="btn btn-secondary" onclick="clearSearchInput()" title="Clear">
@@ -126,17 +133,18 @@
       </div>
     </div>
 
-    <div class="container-fluid">
-      <div class="row row-sortable justify-content-center">
+    <div class="container-fluid mt-2">
+      {% if view_mode in ['cards', 'switch'] -%}
+      <div class="row computer-grid computer-sortable justify-content-center" id="cardsView">
         {% for computer in computers %}
-        <div class="col-lg-3 col-md-6 d-flex computer-card">
+        <div class="col-lg-3 col-md-6 d-flex computer-entry computer-card" data-name="{{ computer.name }}" data-ip="{{ computer.ip_address }}" data-mac="{{ computer.mac_address }}" data-check="{{ computer.test_type }}" data-status="unknown">
           <div class="card mt-2 flex-fill d-flex flex-column">
             <div class="card-body d-flex flex-column flex-grow-1">
               <div class="title-sortable row justify-content-start p-1">
                 <div class="col-auto">
                   <form method="POST" action="{{ url_for('wol_or_sol_send') }}">
                     <input type="hidden" name="mac_address" value="{{ computer.mac_address }}">
-                    <button type="submit" class="btn btn-success btn-circle btn-xl status-power">
+                    <button type="submit" class="btn btn-success btn-circle btn-xl status-power" title="Wake" aria-label="Wake or sleep {{ computer.name }}">
                       <i class="fa-solid fa-power-off"></i>
                     </button>
                   </form>
@@ -187,6 +195,86 @@
         </div>
         {% endfor %}
       </div>
+      {% endif -%}
+
+      {% if view_mode in ['list', 'switch'] -%}
+      <div class="table-responsive computer-list-wrapper{% if view_mode == 'switch' %} hidden{% endif %}" id="listView">
+        <table class="table table-hover align-middle computer-list">
+          <thead>
+            <tr>
+              <th scope="col" class="status-column sortable-column" data-sort="status">On/Off</th>
+              <th scope="col" class="name-column sortable-column" data-sort="name">Name</th>
+              <th scope="col" class="sortable-column" data-sort="ip">IP</th>
+              <th scope="col" class="sortable-column" data-sort="mac">MAC</th>
+              <th scope="col" class="sortable-column" data-sort="check">Check-Method</th>
+              {% if os.environ.get('ENABLE_ADD_DEL') != 'false' -%}
+              <th scope="col" class="actions-column text-end">Actions</th>
+              {% endif -%}
+            </tr>
+          </thead>
+          <tbody class="computer-sortable">
+        {% for computer in computers %}
+          <tr class="computer-entry computer-list-row" data-name="{{ computer.name }}" data-ip="{{ computer.ip_address }}" data-mac="{{ computer.mac_address }}" data-check="{{ computer.test_type }}" data-status="unknown">
+            <td class="text-nowrap">
+              <form method="POST" action="{{ url_for('wol_or_sol_send') }}" class="m-0">
+                <input type="hidden" name="mac_address" value="{{ computer.mac_address }}">
+                <button type="submit" class="btn btn-success btn-circle btn-lg status-power" title="Wake" aria-label="Wake or sleep {{ computer.name }}">
+                  <i class="fa-solid fa-power-off"></i>
+                </button>
+              </form>
+            </td>
+            <td class="computer-name">
+              <div class="sortable fw-semibold">{{ computer.name }}</div>
+              {% if computer.cron_wol_schedule is defined or computer.cron_sol_schedule is defined -%}
+              <div class="schedule-badges">
+                {% if computer.cron_wol_schedule is defined -%}
+                <span class="badge text-bg-success">
+                  <i class="fa-solid fa-arrow-up"></i>
+                  <span>{{ computer.cron_wol_schedule }}</span>
+                </span>
+                {% endif -%}
+                {% if computer.cron_sol_schedule is defined -%}
+                <span class="badge text-bg-danger">
+                  <i class="fa-solid fa-arrow-down"></i>
+                  <span>{{ computer.cron_sol_schedule }}</span>
+                </span>
+                {% endif -%}
+              </div>
+              {% endif -%}
+            </td>
+            <td class="network-address sortable">{{ computer.ip_address }}</td>
+            <td class="network-address sortable">{{ computer.mac_address }}</td>
+            <td>
+              <div class="check-method">
+                <span class="status-indicator asleep" data-ip-address="{{ computer.ip_address }}" data-test-type="{{ computer.test_type }}"></span>
+              {% if computer.test_type in ['icmp', 'arp'] -%}
+                <span class="badge text-bg-secondary">{{ computer.test_type | upper }}</span>
+              {% else -%}
+                <span class="badge text-bg-secondary">TCP {{ computer.test_type }}</span>
+              {% endif -%}
+              </div>
+            </td>
+            {% if os.environ.get('ENABLE_ADD_DEL') != 'false' -%}
+            <td class="text-end">
+              <div class="action-buttons">
+                <button type="button" class="btn btn-primary btn-circle btn-lg" title="Configure Cron" data-bs-toggle="modal" data-bs-target="#cronSettingsModal" onclick="loadCronSettings('{{ computer.name }}', '{{ computer.cron_wol_schedule }}', '{{ computer.cron_sol_schedule }}', '{{ computer.mac_address }}')">
+                  <i class="fa-regular fa-clock"></i>
+                </button>
+                <button type="button" class="btn btn-primary btn-circle btn-lg" title="Edit computer" data-bs-toggle="modal" data-bs-target="#editComputer" data-name="{{ computer.name }}" data-mac-address="{{ computer.mac_address }}" data-ip-address="{{ computer.ip_address }}" data-test-type="{{ computer.test_type }}">
+                  <i class="fa-regular fa-pen-to-square"></i>
+                </button>
+                <button type="button" class="btn btn-danger btn-circle btn-lg" title="Delete computer" data-bs-toggle="modal" data-bs-target="#staticDelete" onclick="setDeleteForm('{{ url_for('delete_computer') }}', 'mac_address', '{{ computer.mac_address }}', 'Computer {{ computer.name }}')">
+                  <i class="fa-regular fa-trash-can"></i>
+                </button>
+              </div>
+            </td>
+            {% endif -%}
+          </tr>
+        {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif -%}
     </div>
 
      <!-- Modal -->


### PR DESCRIPTION
## Summary

This PR adds a list view for the device overview while keeping the existing card layout intact.

It introduces a new `VIEW_MODE` environment variable so deployments can choose how the device overview should be rendered:

- `VIEW_MODE=switch` renders the existing card view by default and shows a UI switch to toggle between card and list views. This is the default behavior.
- `VIEW_MODE=cards` renders only the existing card view and hides the view switch.
- `VIEW_MODE=list` renders only the new list view and hides the view switch.

## List View Details

The new list view includes the requested columns:

- On/Off power action
- Name
- IP
- MAC
- Check-Method
- Scheduling, edit, and delete action icons

The online/offline status indicator is shown in the `Check-Method` column before the check label, for example before `ICMP` or `TCP 443`.

## Sorting and Filtering

- Existing dropdown sorting continues to work.
- The list view table headers are clickable and sortable for `On/Off`, `Name`, `IP`, `MAC`, and `Check-Method`.
- Search/filter behavior works across both card and list views.
- Status refresh updates both representations when the switch mode renders both views.

## Documentation

The README Docker Compose example now documents `VIEW_MODE`, and a dedicated "Device display mode" section explains all supported values and includes an example.

## Verification

Tested locally with:

- `python -m compileall app`
- `git diff --check`
- `docker build -t gptwol-view-mode-test .`
- Docker HTTP smoke tests for `default`, `switch`, `cards`, and `list` modes

Closes #44